### PR TITLE
Draft: Create global struct with info on ships to place on board

### DIFF
--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -17,4 +17,16 @@ constexpr size_t rows = 10;
 constexpr size_t columns = 10;
 using BoardType = std::array<std::array<FieldValue, columns>, rows>;
 
+// Sets how many ships of which types there should be on the board
+constexpr struct {
+    // XX
+    const std::uint_least8_t numSize2 = 4;
+    // XXX
+    const std::uint_least8_t numSize3 = 4;
+    // XXXX
+    const std::uint_least8_t numSize4 = 2;
+    // XXXXX
+    const std::uint_least8_t numSize5 = 2;
+} ShipDistribution;
+
 #endif  // INCLUDE_GUARD_FIELDINFO_HPP


### PR DESCRIPTION
Was created as a consequence of working on #9 but I think it might be useful even outside of the context of that issue. i.e. when working on other parts of the application.

The added code defines a global struct with attributes that store the amount of each type of ship to spawn on the board.

My work on implementing #9 will depend on this (or something very similar) being merged.

@TimBeckmann @Pfege: Please take a look. I got the information on how many ships of each type to place from here: https://www.spielregeln.de/schiffe-versenken.html