### PR TITLE
Better isolate information on board dimensions

### DIFF
--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -13,8 +13,12 @@ enum class FieldValue : std::uint_least8_t {
     PLACEHOLDER
 };
 
-constexpr size_t rows = 10;
-constexpr size_t columns = 10;
-using BoardType = std::array<std::array<FieldValue, columns>, rows>;
+constexpr struct {
+    const size_t rows = 10;
+    const size_t columns = 10;
+} BoardDimensions;
+
+using BoardType = std::array<std::array<FieldValue, BoardDimensions.columns>,
+                             BoardDimensions.rows>;
 
 #endif  // INCLUDE_GUARD_FIELDINFO_HPP


### PR DESCRIPTION
When I looked at `fieldinfo.hpp` again, I got the thought that I chose too simple names for those settings and there's a certain danger that they'll be used or accessed accidentally.

Reading that someone reads from a variable `rows` they have never seen before in the current scope could easily confuse readers unfamiliar with our code, such as Professors.

I believe that putting the variables into an unnamed struct like here would both make the code easier to understand and protect against accidental usage.

However:
* Places where `rows` have been used until now need to be changed to use `BoardDimensions.rows` instead.
* Places where `columns` have been used until now need to be changed to use `BoardDimensions.columns` instead.

Thus this PR might break existing code until it is updated to reflect the new location of the variables.

@TimBeckmann @Pfege: Because this is a breaking change, I want to hear opinions from both of you.

If you think that compatibility should be preserved for now, I can send in another commit, wherein both options can be used but the old constants are marked as `[[deprecated]]`. That way we could have a more graceful transistion to the new way of doing things but will need to remember to delete the old constants later so we actually benefit from the change.