### PR TITLE
C++17 and Sanitizers

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-g++ -std=c++20 -Wall -Wextra -Werror -pedantic -pedantic-errors -march=native -mtune=native -O2 "$1" -pthread
+g++ -std=c++17 -fsanitize=address -fsanitize=leak -fsanitize=undefined \
+    -Wall -Wextra -Werror -pedantic -pedantic-errors -march=native -mtune=native \
+    -O2 "$1" -pthread
 
 if [ -f "$1.clargs" ]
 then


### PR DESCRIPTION
We agreed a few weeks ago that we should use C++17 for our project and this PR applies that decision to run.sh

It also enables a few sanitizers that can detect memory issues and undefined behaviour at runtime at the cost of performance.