### PR TITLE
Fix crash with AddressSanitizer caused by printing a string with missing null-terminator

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -30,7 +30,7 @@ void printGameBoard(const BoardType& board) {
                 ' ',
                 board[lineIndex][columnIndex] == FieldValue::SHIP_HIT ? 'X'
                                                                       : ' ',
-                ' '};
+                ' ', '\0'};
             printf("%s", chars);
         }
         printf(" %c\n", static_cast<char>('A' + lineIndex));


### PR DESCRIPTION
Closes #16