### PR TITLE
Fieldinfo bugfix, adding the == operator and constexpr-ing stuff

### DIFF
--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -35,16 +35,17 @@ struct BoardPoint {
     const std::size_t y;
 
     BoardPoint() = delete;
-    BoardPoint(const std::size_t x, const std::size_t y) : x(x), y(y) {
+    constexpr BoardPoint(const std::size_t x, const std::size_t y)
+        : x(x), y(y) {
         if (x >= BoardDimensions.columns || y >= BoardDimensions.rows)
             throw std::invalid_argument{
                 "BoardPoints must be within the size constraints of the board"};
     }
 
-    BoardPoint operator+(const BoardPoint& otherPoint) const {
+    constexpr BoardPoint operator+(const BoardPoint& otherPoint) const {
         return BoardPoint{this->x + otherPoint.x, this->y + otherPoint.y};
     }
-    BoardPoint operator-(const BoardPoint& otherPoint) const {
+    constexpr BoardPoint operator-(const BoardPoint& otherPoint) const {
         // Leaving out the braces on this if will make gcc 11.1.0 not correctly
         // connect it with the else-block
         if (this->x < otherPoint.x || this->y < otherPoint.y) {
@@ -53,6 +54,10 @@ struct BoardPoint {
                 "underflowed)"};
         } else
             return BoardPoint{this->x - otherPoint.x, this->y - otherPoint.y};
+    }
+
+    constexpr bool operator==(const BoardPoint& otherPoint) const {
+        return this->x == otherPoint.x && this->y == otherPoint.y;
     }
 };
 


### PR DESCRIPTION
It seems that I was too careless when adding BoardPoint to fieldinfo.hpp and forgot to include a
part of the standard library I used. There's a also a bug on the compiler's side that I failed to
find and work around. Those issues are fixed by this PR.

It also:
1. Adds an == operator to BoardPoint that I mistakenly thought would have been provided by the
   language implicitly. It is used by #18 and will need to be provided for that code to work.
1. Applies constexpr to member functions where possible (to enable compile-time optimizations)

@TimBeckmann Please review this PR too. In the mean time, I'll rebase my local copy of #18 to use
these patches before they have been merged in. So no need to hurry.

If you or @Pfege would like an explanation on something in this PR, let me know.
