### PR TITLE
[Chore] Update CI format-checking job to version 4.4.0

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v4.3.1
+      uses: jidicula/clang-format-action@v4.4.0


### PR DESCRIPTION
I'm just updating the CI job responsible for checking for formatting issues.

Since this is a relatively unimportant chore and does not actually touch the C++ code, I will merge this PR without approvals. If anyone has an objection, we can always revert this PR.