### PR TITLE
Increase field size to 15x15 to provide enough space for all ships

### DIFF
--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -15,8 +15,8 @@ enum class FieldValue : std::uint_least8_t {
 };
 
 constexpr struct {
-    const size_t rows = 10;
-    const size_t columns = 10;
+    const size_t rows = 15;
+    const size_t columns = 15;
 } BoardDimensions;
 
 using BoardType = std::array<std::array<FieldValue, BoardDimensions.columns>,


### PR DESCRIPTION
Closes #26

﻿As diagnosed in #18 and tracked in #26, the current requirements make generating boards using #18
an impossibility. Thus the team has decided during today's meeting to increase the board to a size
of 15 * 15 fields.

@TimBeckmann @Pfege This should only be a formality. Could one of you please approve this PR?
