### PR TITLE
Chore: Update clang-format-action to version 4.4.1

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v4.4.0
+      uses: jidicula/clang-format-action@v4.4.1


### PR DESCRIPTION
This version includes [my bugfix](https://github.com/jidicula/clang-format-action/pull/67) for when branchnames have .cpp in their name.