### PR TITLE
Bugfix for getRefFromPoint

### DIFF
--- a/src/boardpoint.cpp
+++ b/src/boardpoint.cpp
@@ -62,10 +62,10 @@ BoardPoint stepsFromPoint(const BoardPoint& originPoint,
 }
 
 FieldValue& getRefFromPoint(BoardType& board, const BoardPoint& point) {
-    return board[point.x][point.y];
+    return board[point.y][point.x];
 }
 
 const FieldValue& getRefFromPoint(const BoardType& board,
                                   const BoardPoint& point) {
-    return board[point.x][point.y];
+    return board[point.y][point.x];
 }


### PR DESCRIPTION
When originally implementing this method, I got the indexes mixed up.

This bugfix was originally part of the gameloop branch/PR but is now being extracted and handled/
merged seperately because it's causing issues with other's work.

@Pfege Would you please review this PR? Once I have merged it, you can rebase your work on master
and not have to deal with this bug anymore when working on #39
