### PR TITLE
Small refactoring in board generator code

### DIFF
--- a/src/board-generator.cpp
+++ b/src/board-generator.cpp
@@ -158,14 +158,10 @@ static void randomlyPlaceShip(BoardType& board, const std::size_t shipLength) {
 static BoardType attemptGeneratingRandomBoard() {
     auto board = generateGameBoardEmpty();
     for (std::size_t shipLength = 2; shipLength < ShipDistribution.size();
-         shipLength++) {
-        if (ShipDistribution[shipLength] == 0)
-            continue;
-
+         shipLength++)
         for (std::uint_fast8_t shipsPlaced = 0;
              shipsPlaced < ShipDistribution[shipLength]; shipsPlaced++)
             randomlyPlaceShip(board, shipLength);
-    }
     return board;
 }
 

--- a/src/board-generator.cpp
+++ b/src/board-generator.cpp
@@ -17,10 +17,10 @@ BoardType generateGameBoardEmpty() {
 
 // file-internal function for generating random value of 32-bit length
 static std::uint_fast32_t genRandom32bitVal() {
-    // rand() alone doesn't give enough guarantees regarding the size of
+    // std::rand() alone doesn't give enough guarantees regarding the size of
     // RAND_MAX for my purposes
     static auto randomNumberGenerator =
-        std::minstd_rand{static_cast<unsigned int>(rand())};
+        std::minstd_rand{static_cast<unsigned int>(std::rand())};
     return randomNumberGenerator();
 }
 
@@ -116,7 +116,7 @@ static void randomlyPlaceShip(BoardType& board, const std::size_t shipLength) {
          placementAttempt++) {
         const BoardPoint selectedPoint = chooseRandomBoardPoint();
         const CardinalDirection direction =
-            static_cast<CardinalDirection>(rand() % 4);
+            static_cast<CardinalDirection>(std::rand() % 4);
 
         try {
             const BoardPoint endPoint =


### PR DESCRIPTION
Removes an unnecessary if statement and makes `rand()` calls explicitly refer to the standard library. (`std::rand()`)

I don't think anything in here is controversial, so I'll merge with the first approval I get. (Provided no changes are requested)