### PR TITLE
Add Dependabot CI job

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+      timezone: "Europe/Berlin"
+    assignees:
+      - "jotoho"
+    reviewers:
+      - "jotoho"


### PR DESCRIPTION
Dependabot is a CI job whose tasks it is to check for outdated packages used in repositories.

In this case the bot is configured to check monthly if any github actions are outdated and, if yes, submit a PR with myself as assignee and reviewer to do the update.
That way we cannot forget to update and lose out on insights and features.

Since this is a new CI job for the repository, I want to make sure that adding it is fine with @TimBeckmann and @Pfege.

If I don't hear from you within a week regarding this PR, I'll assume you do not care.