### PR TITLE
Add copyright headers everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The coordinates must be entered according to the following format:
 
 ```
 SchiffeVersenken - An implementation of Battleships
-Copyright (C) 2021 SchiffeVersenken contributors
+Copyright (C) 2022 SchiffeVersenken contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/include/ai.hpp
+++ b/include/ai.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_AI_HPP
 #define INCLUDE_GUARD_AI_HPP
 

--- a/include/board-generator.hpp
+++ b/include/board-generator.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_BOARDGEN_HPP
 #define INCLUDE_GUARD_BOARDGEN_HPP
 

--- a/include/boardpoint.hpp
+++ b/include/boardpoint.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_BOARDPOINT_HPP
 #define INCLUDE_GUARD_BOARDPOINT_HPP
 

--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_FIELDINFO_HPP
 #define INCLUDE_GUARD_FIELDINFO_HPP
 

--- a/include/gamelogic.hpp
+++ b/include/gamelogic.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_GAMELOGIC_HPP
 #define INCLUDE_GUARD_GAMELOGIC_HPP
 

--- a/include/global-config.hpp
+++ b/include/global-config.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_SCHIFFEVERSENKEN_GLOBALCONF_HPP
 #define INCLUDE_GUARD_SCHIFFEVERSENKEN_GLOBALCONF_HPP
 

--- a/include/input.hpp
+++ b/include/input.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_INPUT_HPP
 #define INCLUDE_GUARD_INPUT_HPP
 

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef INCLUDE_GUARD_OUTPUT_HPP
 #define INCLUDE_GUARD_OUTPUT_HPP
 

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <cstdlib>
 #include <ctime>
 #include <iostream>

--- a/src/board-generator.cpp
+++ b/src/board-generator.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <algorithm>
 #include <random>
 #include <stdexcept>

--- a/src/boardpoint.cpp
+++ b/src/boardpoint.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <algorithm>
 #include <stdexcept>
 

--- a/src/gamelogic.cpp
+++ b/src/gamelogic.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "../include/gamelogic.hpp"
 #include <algorithm>
 #include <cstdint>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <cstdlib>
 #include <iostream>
 #include <type_traits>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <cstdlib>
 #include <ctime>
 #include <iostream>

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,3 +1,21 @@
+/*
+SchiffeVersenken - An implementation of Battleships
+Copyright (C) 2022 SchiffeVersenken contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "../include/output.hpp"
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
Putting the short copyright header for the projects license is considered best-practice for FOSS projects.

These changes do not change the license used by the project (`GPL-3.0-or-later`).

@TimBeckmann: Please review these basic changes.