### PR TITLE
Exclude .exe executables from git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.out
 .vscode
 schiffeversenken
+*.exe


### PR DESCRIPTION
.exe files generated using tools like mingw should not be accidentally added to the repository.

This change is so incredibly unintrusive and small that I will merge it without asking someone else to review it.