### PR TITLE
Fix wrong shift length in 32 bit value generator

### DIFF
--- a/src/board-generator.cpp
+++ b/src/board-generator.cpp
@@ -42,7 +42,7 @@ static std::uint_fast32_t genRandom32bitVal() {
                   std::numeric_limits<std::int_least16_t>::max())
         return std::rand();
     else
-        return (static_cast<std::uint_fast32_t>(std::rand()) << 32U) |
+        return (static_cast<std::uint_fast32_t>(std::rand()) << 16U) |
                std::rand();
 }
 


### PR DESCRIPTION
When trying to build the application for windows, I encountered a compiler warning because
I accidentally set a shift magnitude double of what it should be.

The purpose of that shift operator is to move the bits on the right half of that integer to the left (or MSB) half. Thus using a shift operator of 32 on a 32-bit unsigned integer makes no sense. (Since that would simply delete all bits)

@Pfege Would you please review this tiny change?