### PR TITLE
[Chore] Set clang-format version for CI checker to 14

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -8,3 +8,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.6.0
+      with:
+        clang-format-version: '14'


### PR DESCRIPTION
The CI job we use to check the code for compliance on coding style has now added support for
clang-format 14.

Since Arch Linux does not currently ship clang format 14 yet, this needs to be
tested in a PR.

I'm classifying this change as a chore and not requiring approval to merge.