### PR TITLE
Add SPDX License Identifiers to all .cpp and .hpp source files

### DIFF
--- a/include/ai.hpp
+++ b/include/ai.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/board-generator.hpp
+++ b/include/board-generator.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/boardpoint.hpp
+++ b/include/boardpoint.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/fieldinfo.hpp
+++ b/include/fieldinfo.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/gamelogic.hpp
+++ b/include/gamelogic.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/global-config.hpp
+++ b/include/global-config.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/input.hpp
+++ b/include/input.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/board-generator.cpp
+++ b/src/board-generator.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/boardpoint.cpp
+++ b/src/boardpoint.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/gamelogic.cpp
+++ b/src/gamelogic.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
 SchiffeVersenken - An implementation of Battleships
 Copyright (C) 2022 SchiffeVersenken contributors


### PR DESCRIPTION
This seems to be a recommended practice due to the possibility of automation and the
precision of these identifiers.

This PR does not change the licensing in any way.
It just makes it easier to find and detect.

CC: @TimBeckmann, @Pfege

Merging without approvals, since there's little point to that anymore.
