### PR TITLE
Pin all actions within github workflows to their current version

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -5,7 +5,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.0
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.6.2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2.1.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2.1.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2.1.6

--- a/.github/workflows/compiletest.yml
+++ b/.github/workflows/compiletest.yml
@@ -11,6 +11,6 @@ jobs:
     name: Basic Compiling Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.0
     - name: make
       run: make -j

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lock Threads job
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v3.0.0
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '60'


### PR DESCRIPTION
This should be better for reproducability and allow me more manual control over what is run
on this repository. If any updates show up, dependabot will automatically send in a update PR
anyway.