### PR TITLE
Designate code owners for different parts of the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# This file lists the required experts on specific parts of the repository
+
+# If no other rule applies (additional reviewers may be manually requested)
+* @jotoho
+
+# Repository management, CI & Documentation
+/.github/* @jotoho
+/.clang-format @jotoho
+/LICENSE* @jotoho
+*.sh @jotoho
+*.md @jotoho
+
+# Game AI
+/include/ai.hpp @Pfege @jotoho
+/src/ai.cpp @Pfege @jotoho
+
+# Terminal Input & Output
+/include/input.hpp @TimBeckmann
+/include/output.hpp @TimBeckmann
+/src/input.cpp @TimBeckmann
+/src/output.cpp @TimBeckmann
+
+# Board generation logic
+/include/board-generator.hpp @jotoho
+/include/boardpoint.hpp @jotoho
+/src/board-generator.cpp @jotoho
+/src/boardpoint.cpp @jotoho

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 *.md @jotoho
 
 # Game AI
-/include/ai.hpp @Pfege @jotoho
-/src/ai.cpp @Pfege @jotoho
+/include/ai.hpp @jotoho
+/src/ai.cpp @jotoho
 
 # Terminal Input & Output
 /include/input.hpp @TimBeckmann


### PR DESCRIPTION
This should allow GitHub to automatically call one or more reviewers for any given PR who know
the respecive parts of the codebase.

These required maintainers are also enforced by GitHub, so PRs without their approval cannot be
merged without using admin privileges.

Since this places responsibilities not only on myself but also others, I request reviews from
@TimBeckmann and @Pfege.
